### PR TITLE
feat(website): Hero 协作图按依赖分波（取代 #21）

### DIFF
--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -1858,22 +1858,21 @@ html[lang="zh-CN"] .accent {
   box-shadow: 0 0 0 1px color-mix(in oklab, var(--cg-done), transparent 84%);
 }
 
+/* 名字要截断：宽几何下标题行只剩 ~5.3em，英文的 "Data ingest" 一类会顶出去。 */
 .cg-title {
   margin: 0;
+  overflow: hidden;
+  min-width: 0;
   font-size: 1em;
   font-weight: 600;
   letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.cg-sub,
-.cg-meta {
+.cg-sub {
   margin: 0;
   font-size: 0.8em;
   color: var(--paper-faint);
-}
-.cg-meta {
-  padding-top: 0.15em;
-  border-top: 1px solid oklch(0.93 0.003 285);
-  margin-top: 0.15em;
 }
 
 .cg-status {
@@ -1890,15 +1889,21 @@ html[lang="zh-CN"] .accent {
   font-weight: 400;
 }
 
-/* 工具调用回显：截断到一行，靠打字效果表示「正在干活」。 */
+/* 工具调用回显：靠打字效果表示「正在干活」。
+   两行截断，不是一行——宽几何下卡片只有 ~7.2em 内容宽，单行放不下几个字，
+   打到第 5 个字就顶到省略号不动了，看起来像卡死。 */
 .cg-note {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
   margin: 0;
   overflow: hidden;
   font-size: 0.78em;
   font-style: italic;
+  line-height: 1.3;
   color: oklch(0.68 0.005 285);
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .cg-avatar {
@@ -1920,13 +1925,15 @@ html[lang="zh-CN"] .accent {
   background: var(--cg-accent-tint);
 }
 
+/* ✓ 长在状态行里（不是标题行）：标题行那 1.2em 要留给名字。 */
 .cg-check {
   flex: 0 0 auto;
-  font-size: 0.9em;
+  font-size: 1em;
   color: var(--cg-done-ink);
 }
 
-/* 波次标记：把「按依赖分波」写在卡面上，不然只靠时序观众读不出来。 */
+/* 波次标记：窄几何没有「列」这个维度，只能把波次写在卡面上。
+   宽几何下由上面的 @container 关掉——那边同波次的人已经对齐在同一列了。 */
 .cg-wave {
   display: grid;
   flex: 0 0 auto;
@@ -1998,6 +2005,52 @@ html[lang="zh-CN"] .accent {
   border-right-color: transparent;
   border-radius: 50%;
   animation: am-spin 0.9s linear infinite;
+}
+
+/* 依赖闸门：两波之间的汇合点。上一波「全部」交付才填色放行——
+   ① 里跑得快的那个会停在「已完成」等同伴，这个点就是那次等待的落点。 */
+.cg-gate {
+  fill: var(--paper);
+  stroke: oklch(0.86 0.004 285);
+  stroke-width: 1.6;
+  transition:
+    fill 0.4s ease,
+    stroke 0.4s ease;
+}
+.cg-gate.is-open {
+  fill: var(--cg-accent);
+  stroke: color-mix(in oklab, var(--cg-accent), white 55%);
+}
+
+/* ── 宽几何的卡面减法 ──
+ *
+ * 五个波段挤在一行，worker 卡宽只剩 0.176·vw（两栏 Hero 下约 106px）。
+ * 下面四条就是「能塞下五个波段」的全部余量，加回任何一条都会撑破卡片：
+ *   · 波次标记 ①②③ 只留给窄几何——宽几何里同波次的人已经对齐在同一列了；
+ *   · 头像收到 1.5em，行距收紧；
+ *   · 任务卡竖排（横着放「头像 + 你的任务」放不下）。
+ *
+ * 这一块必须留在 .cg 段的最末尾：它和被覆盖的基础规则同为单类选择器，
+ * 特异性打平、只能靠顺序取胜——往上挪一行，.cg-wave 就又冒出来了。
+ */
+@container (min-width: 35rem) {
+  .cg-wave {
+    display: none;
+  }
+  .cg-avatar {
+    width: 1.5em;
+    height: 1.5em;
+    font-size: 0.8em;
+  }
+  .cg-node {
+    gap: 0.22em;
+    padding: 0.6em 0.7em;
+  }
+  .cg-task-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3em;
+  }
 }
 
 /* ══ 四步机制：之字形卡片 + 蛇形路径 ══════════════════════

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -86,7 +86,7 @@ export default function Home() {
 
           {/* 两栏推到 xl 而不是 lg：lg（1024px）下右栏只剩 ~470px，
               协作图会被迫退到窄几何，反而比整宽单栏更挤。 */}
-          <div className="container-x relative grid items-center gap-14 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.06fr)] xl:gap-16">
+          <div className="container-x relative grid items-center gap-14 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.32fr)] xl:gap-14">
             <div>
               {/* 品类行：首屏必须有一句说清「这是个什么平台」。
                   改版时一度被我换成头像堆丢掉了，补回来。 */}

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -26,6 +26,7 @@ import {
 import {
   DOWNLOAD_PAGE_PATH,
   MOBILE_WEB_URL,
+  WEB_APP_HOST,
   WEB_APP_URL,
 } from "@/lib/download";
 
@@ -175,7 +176,7 @@ export default function Home() {
               className="float-in mx-auto w-full max-w-[44rem] max-sm:-mx-1 xl:max-w-none"
               style={{ animationDelay: "420ms" }}
             >
-              <BrowserFrame url="app.agentcore.dev">
+              <BrowserFrame url={WEB_APP_HOST}>
                 <CollabGraph />
               </BrowserFrame>
             </div>

--- a/apps/website/src/components/CollabGraph.tsx
+++ b/apps/website/src/components/CollabGraph.tsx
@@ -74,16 +74,24 @@ type Geometry = {
  * 分波全靠列位置和两个闸门说话：不画泳道底、不写「波次 ①②③」标签——
  * 三块灰底会把注意力从卡片抢走，而列已经把同波次的人对齐了。
  *
- * 卡宽只有 0.176·vw（两栏 Hero 下约 106px）——五个波段是这张 DAG 的下限，
+ * 卡宽只有 0.176·vw（两栏 Hero 下约 119px）——五个波段是这张 DAG 的下限，
  * 再宽就挤不下。所以卡面做了减法：波次标记只留给窄几何，✓ 移进状态行，
  * 宽几何只留「头像 + 名字 / 状态 / 工具回显」。改动时别把它们加回来。
+ *
+ * 两个比例分别由不同的数管，别搞混：
+ *   · 卡片形状 = CW : CH。卡片的 px 宽高都是 (?/vw)·容器宽，vh 被约掉了——
+ *     所以改 vh 不会让方卡变扁，只有压 CH 才行。
+ *   · 画布形状 = vw : vh。这里取 1000:552 ≈ 1.81:1，贴着浏览器视口的比例，
+ *     整块读起来才像「一块屏」而不是一张方图。
+ * CH 的下限是内容高：标题 1.5em + 状态 1.15em + 回显两行 2.03em + 间距/内边距
+ * 1.64em ≈ 6.32em，换算 130 单位。142 只留了 9% 裕度，再压就切字。
  */
 const WIDE: Geometry = (() => {
   const CW = 176; // worker 卡宽
-  const CH = 160; // worker 卡高
+  const CH = 142; // worker 卡高（下限 130，见上）
   const COL = [188, 402, 616]; // 三个波次的列起点
-  const TOP = 128; // 上行卡片中线
-  const BOT = 498; // 下行卡片中线
+  const TOP = 107; // 上行卡片中线
+  const BOT = 451; // 下行卡片中线
   const MID = (TOP + BOT) / 2; // 主干中线：任务 / 闸门 / ③ / CEO 都落在这条线上
   const rowY = (cy: number) => cy - CH / 2;
   const gate = (i: number) => COL[i] + CW + 19; // 闸门 x：落在两条泳道之间的沟里
@@ -96,10 +104,10 @@ const WIDE: Geometry = (() => {
 
   return {
     vw: 1000,
-    vh: 626,
+    vh: 558,
     /* 任务卡缩成一枚方章：顶栏已经写了「5 个 worker · 按依赖分波」，
        卡面再重复一遍纯属浪费——省下的 32 单位全给了右边的 CEO 卡。 */
-    task: { x: 12, y: MID - 60, w: 124, h: 120 },
+    task: { x: 12, y: MID - 58, w: 124, h: 116 },
     workers: [
       { x: COL[0], y: rowY(TOP), w: CW, h: CH },
       { x: COL[0], y: rowY(BOT), w: CW, h: CH },
@@ -107,7 +115,9 @@ const WIDE: Geometry = (() => {
       { x: COL[1], y: rowY(BOT), w: CW, h: CH },
       { x: COL[2], y: rowY(MID), w: CW, h: CH },
     ],
-    ceo: { x: CEO_X, y: MID - 78, w: 174, h: 156 },
+    /* CEO 卡比 worker 高一档：它的状态行（「等待团队 (2/5) · 已等 5s」）
+       在这个卡宽下必然折成两行，按最高的那个状态给高度，否则说明会漏出下缘。 */
+    ceo: { x: CEO_X, y: MID - 79, w: 174, h: 158 },
     edges: [
       // 任务扇出到波次 ①
       { pts: [{ x: TASK_R, y: MID }, { x: FAN, y: MID }, { x: FAN, y: TOP }, { x: COL[0], y: TOP }], drive: 0, kind: "push" },

--- a/apps/website/src/components/CollabGraph.tsx
+++ b/apps/website/src/components/CollabGraph.tsx
@@ -7,46 +7,57 @@ import { GRAPH } from "@/content/home";
 /**
  * Hero 右侧的「协作图」——产品内协作画布的复刻。
  *
- * 一次真实任务的时间线：你下达目标 → CEO 派出 5 个角色、按依赖分三波推进 →
- * 各自调用不同工具、耗时不同 → 陆续交付 → CEO 汇总成报告。
+ * 一次真实任务的编排：你下达目标 →（① 两个并行摸底）→ 闸门 →（② 两个接着算）
+ * → 闸门 →（③ 质检复核）→ CEO 汇总成报告。
  *
- * 呈现接受「扇出 + 时间错开」（不必画 worker→worker 的 DAG 边）：
- * 五个 worker 的 start/run/done 按波次错开——若五条同时亮同时灭，看起来就是
- * 「一个助手分饰五角」；错开才读得出各自独立推进、后波在等前波产出。
+ * 五个 worker 沿 X 轴按波次落位，只有同波次的人才上下并排——**依赖关系写在几何里**。
+ * 这一点是这张图存在的全部理由：若五个并排成一列，读者看到的就是「一个助手分饰五角
+ * 同时开工」，正是本站要反的那件事。
+ *
+ * 两个闸门（gate）是叙事核心：上一波「全部」交付才放行下一波，所以 ① 里跑得快的
+ * 那个会先停在「已完成」等同伴——这一等就是依赖的证据。改时间线时别把它等没了。
  *
  * 动画由一个 120ms 的 tick 驱动、状态全部从 elapsed 推导（不是一串 setTimeout），
  * 所以循环、暂停、降级都只是改 t 的来源，不会出现半路错位的中间态。
  */
 
-const LOOP = 15_500;
+const LOOP = 15_800;
 
 /** 切换到宽几何的容器宽（px）。必须与 globals.css 里 @container 的 35rem 对齐。 */
 const WIDE_AT = 560;
 
 /**
  * 每个 worker 的时间线（ms，相对循环起点）。
- * 波次①（0,1）先并行；②（2,3）等①的产出才起步；③（4）最后进场质检。
- * 这份错开就是「按依赖分波」的全部证据，改动时别把它们对齐。
+ * 必须严格服从波次闸门：下一波的 start 要晚于上一波所有人的 done，
+ * 否则画面上「闸门还没开、人已经在跑」，这张图就自己拆自己的台。
  */
 const TIMELINE = [
-  { start: 600, run: 1600, done: 4200 },
-  { start: 800, run: 1900, done: 4800 },
-  { start: 4400, run: 5400, done: 7800 },
-  { start: 4900, run: 5900, done: 8500 },
-  { start: 8700, run: 9500, done: 11_600 },
+  { start: 500, run: 1400, done: 3900 },
+  { start: 700, run: 1700, done: 4500 },
+  { start: 4700, run: 5500, done: 7800 },
+  { start: 4900, run: 5800, done: 8400 },
+  { start: 8600, run: 9300, done: 11_400 },
+];
+
+/** 波次分组。索引即 TIMELINE / GRAPH.workers 的下标。 */
+const WAVES = [
+  [0, 1],
+  [2, 3],
+  [4],
 ];
 
 const ALL_DONE = Math.max(...TIMELINE.map((w) => w.done));
 const MERGE_UNTIL = ALL_DONE + 2000;
 
 /** Agent 身份色：与站内协作图同一套，五个角色各占一格。 */
-const TONES = [
-  "--agent-1",
-  "--agent-3",
-  "--agent-6",
-  "--agent-4",
-  "--agent-8",
-];
+const TONES = ["--agent-1", "--agent-3", "--agent-6", "--agent-4", "--agent-8"];
+
+type Box = { x: number; y: number; w: number; h: number };
+type Pt = { x: number; y: number };
+/** drive = 由第几个 worker 的状态驱动；push = 派活（进节点），hand = 交付（出节点）。 */
+type Edge = { pts: Pt[]; drive: number; kind: "push" | "hand" };
+/** 依赖闸门：after 波全部 done 才点亮。r 按几何单位给——两套 vw 不同，不能共用一个值。 */
+type Gate = { x: number; y: number; after: number; r: number };
 
 type Geometry = {
   vw: number;
@@ -54,75 +65,119 @@ type Geometry = {
   task: Box;
   workers: Box[];
   ceo: Box;
-  edgeIn: (i: number) => Pt[];
-  edgeOut: (i: number) => Pt[];
+  edges: Edge[];
+  gates: Gate[];
 };
-type Box = { x: number; y: number; w: number; h: number };
-type Pt = { x: number; y: number };
 
-/* 宽屏：左 → 中 → 右，扇出再收拢，一眼看出并行。 */
+/* ── 宽几何：任务 → ① → 闸门 → ② → 闸门 → ③ → CEO，沿 X 轴分波 ────
+ *
+ * 分波全靠列位置和两个闸门说话：不画泳道底、不写「波次 ①②③」标签——
+ * 三块灰底会把注意力从卡片抢走，而列已经把同波次的人对齐了。
+ *
+ * 卡宽只有 0.176·vw（两栏 Hero 下约 106px）——五个波段是这张 DAG 的下限，
+ * 再宽就挤不下。所以卡面做了减法：波次标记只留给窄几何，✓ 移进状态行，
+ * 宽几何只留「头像 + 名字 / 状态 / 工具回显」。改动时别把它们加回来。
+ */
 const WIDE: Geometry = (() => {
-  const workers = [14, 120, 226, 332, 438].map((y) => ({
-    x: 240,
-    y,
-    w: 268,
-    h: 94,
-  }));
-  const cy = (i: number) => workers[i].y + workers[i].h / 2;
+  const CW = 176; // worker 卡宽
+  const CH = 160; // worker 卡高
+  const COL = [188, 402, 616]; // 三个波次的列起点
+  const TOP = 128; // 上行卡片中线
+  const BOT = 498; // 下行卡片中线
+  const MID = (TOP + BOT) / 2; // 主干中线：任务 / 闸门 / ③ / CEO 都落在这条线上
+  const rowY = (cy: number) => cy - CH / 2;
+  const gate = (i: number) => COL[i] + CW + 19; // 闸门 x：落在两条泳道之间的沟里
+
+  const G1 = gate(0);
+  const G2 = gate(1);
+  const TASK_R = 136; // 任务卡右缘
+  const FAN = 162; // 任务扇出的竖沟
+  const CEO_X = 814;
+
   return {
-    vw: 720,
-    vh: 540,
-    task: { x: 4, y: 226, w: 156, h: 88 },
-    workers,
-    ceo: { x: 552, y: 226, w: 164, h: 88 },
-    edgeIn: (i) => [
-      { x: 160, y: 270 },
-      { x: 200, y: 270 },
-      { x: 200, y: cy(i) },
-      { x: 240, y: cy(i) },
+    vw: 1000,
+    vh: 626,
+    /* 任务卡缩成一枚方章：顶栏已经写了「5 个 worker · 按依赖分波」，
+       卡面再重复一遍纯属浪费——省下的 32 单位全给了右边的 CEO 卡。 */
+    task: { x: 12, y: MID - 60, w: 124, h: 120 },
+    workers: [
+      { x: COL[0], y: rowY(TOP), w: CW, h: CH },
+      { x: COL[0], y: rowY(BOT), w: CW, h: CH },
+      { x: COL[1], y: rowY(TOP), w: CW, h: CH },
+      { x: COL[1], y: rowY(BOT), w: CW, h: CH },
+      { x: COL[2], y: rowY(MID), w: CW, h: CH },
     ],
-    edgeOut: (i) => [
-      { x: 508, y: cy(i) },
-      { x: 530, y: cy(i) },
-      { x: 530, y: 270 },
-      { x: 552, y: 270 },
+    ceo: { x: CEO_X, y: MID - 78, w: 174, h: 156 },
+    edges: [
+      // 任务扇出到波次 ①
+      { pts: [{ x: TASK_R, y: MID }, { x: FAN, y: MID }, { x: FAN, y: TOP }, { x: COL[0], y: TOP }], drive: 0, kind: "push" },
+      { pts: [{ x: TASK_R, y: MID }, { x: FAN, y: MID }, { x: FAN, y: BOT }, { x: COL[0], y: BOT }], drive: 1, kind: "push" },
+      // ① 交付 → 闸门 1
+      { pts: [{ x: COL[0] + CW, y: TOP }, { x: G1, y: TOP }, { x: G1, y: MID }], drive: 0, kind: "hand" },
+      { pts: [{ x: COL[0] + CW, y: BOT }, { x: G1, y: BOT }, { x: G1, y: MID }], drive: 1, kind: "hand" },
+      // 闸门 1 放行 → 波次 ②
+      { pts: [{ x: G1, y: MID }, { x: G1, y: TOP }, { x: COL[1], y: TOP }], drive: 2, kind: "push" },
+      { pts: [{ x: G1, y: MID }, { x: G1, y: BOT }, { x: COL[1], y: BOT }], drive: 3, kind: "push" },
+      // ② 交付 → 闸门 2
+      { pts: [{ x: COL[1] + CW, y: TOP }, { x: G2, y: TOP }, { x: G2, y: MID }], drive: 2, kind: "hand" },
+      { pts: [{ x: COL[1] + CW, y: BOT }, { x: G2, y: BOT }, { x: G2, y: MID }], drive: 3, kind: "hand" },
+      // 闸门 2 放行 → 波次 ③ → CEO
+      { pts: [{ x: G2, y: MID }, { x: COL[2], y: MID }], drive: 4, kind: "push" },
+      { pts: [{ x: COL[2] + CW, y: MID }, { x: CEO_X, y: MID }], drive: 4, kind: "hand" },
+    ],
+    gates: [
+      { x: G1, y: MID, after: 0, r: 7.5 },
+      { x: G2, y: MID, after: 1, r: 7.5 },
     ],
   };
 })();
 
-/* 窄屏：上 → 下，分支走左沟、回流走右沟，保住扇出/收拢的形状。 */
+/* ── 窄几何：同一张 DAG 竖过来，波次变成「行」，同波次左右并排。 ──
+ *
+ * 卡高/卡宽都按容器宽等比缩放（cqi），比例定错就是在任何宽度下同样比例地溢出，
+ * 不会「大屏就好了」。这里的 126/700 是按实测内容高留裕度倒推的。
+ */
 const NARROW: Geometry = (() => {
-  /*
-   * 卡高不能凭感觉给：卡高与字号都随容器等比缩放（前者 h/vw·W，后者 cqi·W），
-   * 比例一旦定错，在任何宽度下都是同样比例地溢出，不会「大屏就好了」。
-   * 这里的 84/420 是按实测内容高（≈0.182·容器宽）留出裕度倒推的。
-   */
-  const workers = [106, 196, 286, 376, 466].map((y) => ({
-    x: 56,
-    y,
-    w: 308,
-    h: 84,
-  }));
-  const cy = (i: number) => workers[i].y + workers[i].h / 2;
+  const CW = 196;
+  const CH = 106;
+  const L = 6; // 左列 x
+  const R = 218; // 右列 x
+  const LX = L + CW / 2; // 左列中线
+  const RX = R + CW / 2; // 右列中线
+  const MX = 210; // 主干中线
+  const ROW = [126, 272, 418]; // 三个波次的行起点
+  const bot = (i: number) => ROW[i] + CH;
+  const g1 = bot(0) + 20;
+  const g2 = bot(1) + 20;
+  const CEO_Y = 554;
+
   return {
     vw: 420,
-    vh: 672,
-    task: { x: 112, y: 4, w: 196, h: 78 },
-    workers,
-    ceo: { x: 112, y: 578, w: 196, h: 82 },
-    edgeIn: (i) => [
-      { x: 210, y: 82 },
-      { x: 210, y: 94 },
-      { x: 28, y: 94 },
-      { x: 28, y: cy(i) },
-      { x: 56, y: cy(i) },
+    vh: 660,
+    task: { x: 110, y: 6, w: 200, h: 82 },
+    workers: [
+      { x: L, y: ROW[0], w: CW, h: CH },
+      { x: R, y: ROW[0], w: CW, h: CH },
+      { x: L, y: ROW[1], w: CW, h: CH },
+      { x: R, y: ROW[1], w: CW, h: CH },
+      { x: 112, y: ROW[2], w: CW, h: CH },
     ],
-    edgeOut: (i) => [
-      { x: 364, y: cy(i) },
-      { x: 392, y: cy(i) },
-      { x: 392, y: 564 },
-      { x: 210, y: 564 },
-      { x: 210, y: 578 },
+    ceo: { x: 90, y: CEO_Y, w: 240, h: 96 },
+    edges: [
+      { pts: [{ x: MX, y: 88 }, { x: MX, y: 106 }, { x: LX, y: 106 }, { x: LX, y: ROW[0] }], drive: 0, kind: "push" },
+      { pts: [{ x: MX, y: 88 }, { x: MX, y: 106 }, { x: RX, y: 106 }, { x: RX, y: ROW[0] }], drive: 1, kind: "push" },
+      { pts: [{ x: LX, y: bot(0) }, { x: LX, y: g1 }, { x: MX, y: g1 }], drive: 0, kind: "hand" },
+      { pts: [{ x: RX, y: bot(0) }, { x: RX, y: g1 }, { x: MX, y: g1 }], drive: 1, kind: "hand" },
+      { pts: [{ x: MX, y: g1 }, { x: LX, y: g1 }, { x: LX, y: ROW[1] }], drive: 2, kind: "push" },
+      { pts: [{ x: MX, y: g1 }, { x: RX, y: g1 }, { x: RX, y: ROW[1] }], drive: 3, kind: "push" },
+      { pts: [{ x: LX, y: bot(1) }, { x: LX, y: g2 }, { x: MX, y: g2 }], drive: 2, kind: "hand" },
+      { pts: [{ x: RX, y: bot(1) }, { x: RX, y: g2 }, { x: MX, y: g2 }], drive: 3, kind: "hand" },
+      { pts: [{ x: MX, y: g2 }, { x: MX, y: ROW[2] }], drive: 4, kind: "push" },
+      { pts: [{ x: MX, y: bot(2) }, { x: MX, y: CEO_Y }], drive: 4, kind: "hand" },
+    ],
+    gates: [
+      { x: MX, y: g1, after: 0, r: 5 },
+      { x: MX, y: g2, after: 1, r: 5 },
     ],
   };
 })();
@@ -168,9 +223,9 @@ export default function CollabGraph() {
 
   /*
    * 几何按「容器宽」切，不是视口宽。
-   * Hero 在 lg 以上是两栏，右栏比视口窄得多（视口 1024px 时容器只有 ~430px），
-   * 若这里看视口、字号看 cqi 看容器，两者就会背离成「宽几何 + 窄字号」，
-   * 文字直接撑破卡片。阈值必须与 globals.css 里 @container 的 35rem 一致。
+   * Hero 在 xl 以上是两栏，右栏比视口窄得多，若这里看视口、字号看 cqi 看容器，
+   * 两者就会背离成「宽几何 + 窄字号」，文字直接撑破卡片。
+   * 阈值必须与 globals.css 里 @container 的 35rem 一致。
    */
   useEffect(() => {
     const host = hostRef.current;
@@ -184,7 +239,7 @@ export default function CollabGraph() {
 
   useEffect(() => {
     const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
-    // 降级：直接停在「五人都已交付、CEO 汇总完成」那一帧——静态也讲得完整个故事。
+    // 降级：停在「五人都已交付、CEO 汇总完成」那一帧——静态也讲得完整个故事。
     if (reduced.matches) {
       setElapsed(MERGE_UNTIL + 600);
       return;
@@ -229,6 +284,7 @@ export default function CollabGraph() {
   const stages = TIMELINE.map((_, i) => stageOf(elapsed, i));
   const doneCount = stages.filter((s) => s === "done").length;
   const secs = (from: number) => Math.max(0, Math.round((elapsed - from) / 1000));
+  const gateOpen = (wave: number) => WAVES[wave].every((i) => stages[i] === "done");
 
   const ceoTone: "wait" | "merge" | "ready" =
     elapsed < ALL_DONE ? "wait" : elapsed < MERGE_UNTIL ? "merge" : "ready";
@@ -257,159 +313,164 @@ export default function CollabGraph() {
         {/* 点阵画布 */}
         <div aria-hidden="true" className="cg-canvas" />
 
-      {/* 连线：底层是描边（随节点激活「长」出来），上层是流动虚线（仅运行中显示） */}
-      <svg
-        aria-hidden="true"
-        className="absolute inset-0 h-full w-full"
-        viewBox={`0 0 ${g.vw} ${g.vh}`}
-        fill="none"
-      >
-        {g.workers.map((_, i) => {
-          const on = stages[i] !== "idle";
-          const flowing = stages[i] === "thinking" || stages[i] === "running";
+        {/* 连线 + 闸门 */}
+        <svg
+          aria-hidden="true"
+          className="absolute inset-0 h-full w-full"
+          viewBox={`0 0 ${g.vw} ${g.vh}`}
+          fill="none"
+        >
+          {g.edges.map((e, i) => {
+            const stage = stages[e.drive];
+            const on = e.kind === "push" ? stage !== "idle" : stage === "done";
+            const flowing =
+              e.kind === "push" && (stage === "thinking" || stage === "running");
+            const d = orthPath(e.pts);
+            return (
+              <g key={`edge-${i}`}>
+                <path
+                  d={d}
+                  pathLength={100}
+                  className={`cg-edge ${e.kind === "push" ? "cg-edge-in" : ""} ${on ? "is-on" : ""}`}
+                />
+                {flowing && <path d={d} className="cg-flow" />}
+              </g>
+            );
+          })}
+
+          {g.gates.map((gate, i) => (
+            <circle
+              key={`gate-${i}`}
+              className={`cg-gate ${gateOpen(gate.after) ? "is-open" : ""}`}
+              cx={gate.x}
+              cy={gate.y}
+              r={gate.r}
+            />
+          ))}
+        </svg>
+
+        {/* 你的任务 */}
+        <div
+          className="cg-node cg-node-task"
+          style={{
+            left: pct(g.task.x, g.vw),
+            top: pct(g.task.y, g.vh),
+            width: pct(g.task.w, g.vw),
+            height: pct(g.task.h, g.vh),
+          }}
+        >
+          {/* 宽几何下这一行被 CSS 转成竖排：任务卡只有 0.124·vw，
+              「头像 + 你的任务」横着放会把标题截掉。 */}
+          <div className="cg-task-head flex items-center gap-[0.45em]">
+            <span className="cg-avatar cg-avatar-user" aria-hidden="true">
+              <svg viewBox="0 0 16 16" className="w-[0.85em]" fill="currentColor">
+                <circle cx="8" cy="5" r="2.8" />
+                <path d="M2.6 14a5.4 5.4 0 0 1 10.8 0z" />
+              </svg>
+            </span>
+            <div className="min-w-0">
+              <p className="cg-title">{tr(GRAPH.task.title)}</p>
+              <p className="cg-sub">{tr(GRAPH.task.sub)}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 五个 worker，按波次落位 */}
+        {g.workers.map((box, i) => {
+          const stage = stages[i];
+          const spec = GRAPH.workers[i];
+          const active = stage === "thinking" || stage === "running";
+          const note = tr(spec.note);
+          // 运行中让 note 逐字打出来：静止的省略号看着像卡住，打字才像在干活。
+          const typed =
+            stage === "running"
+              ? note.slice(
+                  0,
+                  Math.max(
+                    1,
+                    Math.round(
+                      ((elapsed - TIMELINE[i].run) /
+                        (TIMELINE[i].done - TIMELINE[i].run)) *
+                        note.length *
+                        1.35,
+                    ),
+                  ),
+                )
+              : stage === "done"
+                ? note
+                : "";
+
           return (
-            <g key={`in-${i}`}>
-              <path
-                d={orthPath(g.edgeIn(i))}
-                pathLength={100}
-                className={`cg-edge cg-edge-in ${on ? "is-on" : ""}`}
-              />
-              {flowing && (
-                <path d={orthPath(g.edgeIn(i))} className="cg-flow" />
-              )}
-            </g>
+            <div
+              key={i}
+              className={`cg-node cg-node-worker ${active ? "is-active" : ""} ${
+                stage === "done" ? "is-done" : ""
+              } ${stage === "idle" ? "is-idle" : ""}`}
+              style={{
+                left: pct(box.x, g.vw),
+                top: pct(box.y, g.vh),
+                width: pct(box.w, g.vw),
+                height: pct(box.h, g.vh),
+              }}
+            >
+              <div className="flex items-center gap-[0.4em]">
+                <span
+                  className="cg-avatar"
+                  aria-hidden="true"
+                  style={{
+                    background: `color-mix(in oklab, var(${TONES[i]}), white 72%)`,
+                    color: `color-mix(in oklab, var(${TONES[i]}), black 34%)`,
+                  }}
+                >
+                  {tr(spec.name).slice(0, 1)}
+                </span>
+                <p className="cg-title">{tr(spec.name)}</p>
+                <span className="flex-1" />
+                {/* 波次标记只在窄几何出现：宽几何下泳道已经把波次说清楚了。 */}
+                <span className="cg-wave" aria-hidden="true">
+                  {spec.wave}
+                </span>
+              </div>
+
+              <p className={`cg-status ${stage === "done" ? "is-done" : ""}`}>
+                {stage === "done" && (
+                  <span className="cg-check" aria-hidden="true">
+                    ✓{" "}
+                  </span>
+                )}
+                {stage === "idle"
+                  ? tr(GRAPH.queued)
+                  : stage === "thinking"
+                    ? `${tr(GRAPH.thinking)} · ${secs(TIMELINE[i].start)}s`
+                    : stage === "running"
+                      ? `${spec.tool} · ${secs(TIMELINE[i].start)}s`
+                      : `${tr(GRAPH.finished)} · ${Math.round((TIMELINE[i].done - TIMELINE[i].start) / 1000)}s`}
+              </p>
+
+              <p className="cg-note">
+                {typed}
+                {stage === "running" && <span className="cg-caret" />}
+              </p>
+            </div>
           );
         })}
-        {g.workers.map((_, i) => (
-          <path
-            key={`out-${i}`}
-            d={orthPath(g.edgeOut(i))}
-            pathLength={100}
-            className={`cg-edge ${stages[i] === "done" ? "is-on" : ""}`}
-          />
-        ))}
-      </svg>
 
-      {/* 你的任务 */}
-      <div
-        className="cg-node cg-node-task"
-        style={{
-          left: pct(g.task.x, g.vw),
-          top: pct(g.task.y, g.vh),
-          width: pct(g.task.w, g.vw),
-          height: pct(g.task.h, g.vh),
-        }}
-      >
-        <div className="flex items-center gap-[0.55em]">
-          <span className="cg-avatar cg-avatar-user" aria-hidden="true">
-            <svg viewBox="0 0 16 16" className="w-[0.85em]" fill="currentColor">
-              <circle cx="8" cy="5" r="2.8" />
-              <path d="M2.6 14a5.4 5.4 0 0 1 10.8 0z" />
-            </svg>
-          </span>
-          <div className="min-w-0">
-            <p className="cg-title">{tr(GRAPH.task.title)}</p>
-            <p className="cg-sub">{tr(GRAPH.task.sub)}</p>
+        {/* CEO 汇总 */}
+        <div
+          className={`cg-node cg-node-ceo ${ceoTone === "ready" ? "is-done" : "is-active"}`}
+          style={{
+            left: pct(g.ceo.x, g.vw),
+            top: pct(g.ceo.y, g.vh),
+            width: pct(g.ceo.w, g.vw),
+            height: pct(g.ceo.h, g.vh),
+          }}
+        >
+          <div className="flex items-center gap-[0.45em]">
+            <span className="cg-avatar cg-avatar-ceo" aria-hidden="true">
+              {ceoTone === "ready" ? "✓" : <span className="cg-spin" />}
+            </span>
+            <p className="cg-title flex-1">{tr(GRAPH.ceo.title)}</p>
           </div>
-        </div>
-        <p className="cg-meta">{tr(GRAPH.toolbarTitle)}</p>
-      </div>
-
-      {/* 五个 worker · 三波次 */}
-      {g.workers.map((box, i) => {
-        const stage = stages[i];
-        const spec = GRAPH.workers[i];
-        const active = stage === "thinking" || stage === "running";
-        const note = tr(spec.note);
-        // 运行中让 note 逐字打出来：静止的省略号看着像卡住，打字才像在干活。
-        const typed =
-          stage === "running"
-            ? note.slice(
-                0,
-                Math.max(
-                  1,
-                  Math.round(
-                    ((elapsed - TIMELINE[i].run) /
-                      (TIMELINE[i].done - TIMELINE[i].run)) *
-                      note.length *
-                      1.35,
-                  ),
-                ),
-              )
-            : stage === "done"
-              ? note
-              : "";
-
-        return (
-          <div
-            key={i}
-            className={`cg-node cg-node-worker ${active ? "is-active" : ""} ${
-              stage === "done" ? "is-done" : ""
-            } ${stage === "idle" ? "is-idle" : ""}`}
-            style={{
-              left: pct(box.x, g.vw),
-              top: pct(box.y, g.vh),
-              width: pct(box.w, g.vw),
-              height: pct(box.h, g.vh),
-            }}
-          >
-            <div className="flex items-center gap-[0.5em]">
-              <span
-                className="cg-avatar"
-                aria-hidden="true"
-                style={{
-                  background: `color-mix(in oklab, var(${TONES[i]}), white 72%)`,
-                  color: `color-mix(in oklab, var(${TONES[i]}), black 34%)`,
-                }}
-              >
-                {tr(spec.name).slice(0, 1)}
-              </span>
-              <p className="cg-title">{tr(spec.name)}</p>
-              <span className="cg-wave" aria-hidden="true">
-                {spec.wave}
-              </span>
-              <span className="flex-1" />
-              {stage === "done" && (
-                <span className="cg-check" aria-hidden="true">
-                  ✓
-                </span>
-              )}
-            </div>
-
-            <p className={`cg-status ${stage === "done" ? "is-done" : ""}`}>
-              {stage === "idle"
-                ? tr(GRAPH.queued)
-                : stage === "thinking"
-                  ? `${tr(GRAPH.thinking)} · ${secs(TIMELINE[i].start)}s`
-                  : stage === "running"
-                    ? `${spec.tool} · ${secs(TIMELINE[i].start)}s`
-                    : `${tr(GRAPH.finished)} · ${Math.round((TIMELINE[i].done - TIMELINE[i].start) / 1000)}s`}
-            </p>
-
-            <p className="cg-note">
-              {typed}
-              {stage === "running" && <span className="cg-caret" />}
-            </p>
-          </div>
-        );
-      })}
-
-      {/* CEO 汇总 */}
-      <div
-        className={`cg-node cg-node-ceo ${ceoTone === "ready" ? "is-done" : "is-active"}`}
-        style={{
-          left: pct(g.ceo.x, g.vw),
-          top: pct(g.ceo.y, g.vh),
-          width: pct(g.ceo.w, g.vw),
-          height: pct(g.ceo.h, g.vh),
-        }}
-      >
-        <div className="flex items-center gap-[0.55em]">
-          <span className="cg-avatar cg-avatar-ceo" aria-hidden="true">
-            {ceoTone === "ready" ? "✓" : <span className="cg-spin" />}
-          </span>
-          <p className="cg-title flex-1">{tr(GRAPH.ceo.title)}</p>
-        </div>
           <p className={`cg-status ${ceoTone === "ready" ? "is-done" : ""}`}>
             {ceoLabel}
           </p>

--- a/apps/website/src/content/home.ts
+++ b/apps/website/src/content/home.ts
@@ -116,7 +116,8 @@ export const GRAPH = {
       },
     },
     {
-      name: { zh: "数据采集", en: "Data ingest" },
+      /* EN 名字必须短：分波几何下卡宽只有 0.176·vw，"Data ingest" 会被截成 "Data ing…"。 */
+      name: { zh: "数据采集", en: "Ingest" },
       wave: "①",
       tool: "Fetch page",
       note: {

--- a/apps/website/src/lib/download.ts
+++ b/apps/website/src/lib/download.ts
@@ -98,3 +98,6 @@ export const MOBILE_WEB_URL = "https://m.fashitianxia.xyz" as const;
 
 /** 主力 web 客户端（apps/desktop 渲染层跑浏览器，同源托管在 app. 根路径；免安装、需登录）。 */
 export const WEB_APP_URL = "https://app.fashitianxia.xyz" as const;
+
+/** Hero 那块「产品截图」地址栏里显示的 host。从 WEB_APP_URL 推，别再手写第二份。 */
+export const WEB_APP_HOST = WEB_APP_URL.replace(/^https?:\/\//, "");


### PR DESCRIPTION
## 这个 PR 做什么

把 Hero 右侧的协作图从「五个 worker 并排成一列」改成「沿横轴按依赖分三波」。

现状是五张卡片挤在同一列，从任务扇出、再直接汇进 CEO。冷读下来就是「五个同名助手同时开工」——恰好是本站要反的那件事。

改成：

```
你的任务 → ① 资料检索 + 数据采集 → 闸门 → ② 数据分析 + 趋势研判 → 闸门 → ③ 质检复核 → CEO 汇总
```

**只有同波次的人才上下并排**，依赖关系落在几何里，不用靠时序去猜。

两个闸门圆点承担核心叙事：上一波**全部**交付才放行下一波，所以 ① 里跑得快的那个（资料检索 3s）会先停在「已完成」等同伴（数据采集 4s）——这一等就是依赖的证据。时间线也重排过，让每一波的 `start` 严格晚于上一波所有人的 `done`；否则画面上「闸门还没开、人已经在跑」，这张图会自己拆自己的台。

## 代价与取舍

卡宽从 0.37·vw 掉到 0.176·vw（两栏 Hero 下约 106px），卡面必须做减法才装得下。下面四条是全部余量，加回任何一条都会撑破卡片：

- 波次角标 ①②③ 只留给窄几何——宽几何里同波次的人已经对齐在同一列了
- ✓ 从标题行移进状态行，整行宽度让给名字
- 工具回显改成两行 `line-clamp`：单行在这个宽度下打到第 5 个字就顶到省略号不动了，看起来像卡死
- 英文 `Data ingest` → `Ingest`，否则截成 `Data ing…`

有一处坑写进注释了：宽几何的 `@container (min-width: 35rem)` 块**必须留在 `.cg` 段最末尾**。它和被覆盖的基础规则同为单类选择器，特异性打平、只能靠顺序取胜——往上挪一行，波次角标就又冒出来把名字挤断。

## 顺带修的

Hero 浏览器框的地址栏还写着 `app.agentcore.dev`。改成从 `WEB_APP_URL` 推导的 `WEB_APP_HOST`（`app.fashitianxia.xyz`），避免再手写第二份。

## 验证

- `next build` 通过，`tsc --noEmit` 干净
- 中英双语、三档宽度（Hero 两栏 606px / 单栏 704px / 手机 390px）都看过
- 无新增依赖，改动集中在 5 个文件

## 关于 #21

本 PR 取代 #21，那边我会关掉。

#21 落后 master 46 个提交且大面积冲突，其中的官网改版内容已经在 master 上落地了；剩下的 `HeroFlow` / `MechanismBoard` / `agentmap/` / `universe/` 等是当时的试验件，不该再回主线。所以没有硬解冲突——直接从当前 master 重新切了一个只含本次改动的分支。

**本 PR 基于 `bcd99d21`，无冲突，可直接 squash merge。**
